### PR TITLE
Add SilverStripe 6 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
         "homepage": "http://www.innoweb.com.au"
     }],
     "require": {
-        "silverstripe/cms": "^5",
-        "silverstripe/vendor-plugin": "^2",
-        "silvershop/core": "^3.1",
+        "silverstripe/cms": "^5 || ^6",
+        "silverstripe/vendor-plugin": "^2 || ^3",
+        "silvershop/core": "^3.1 || dev-main",
         "omnipay/stripe": "^3.0"
     },
     "autoload": {

--- a/src/Checkout/Components/StripeOnsitePayment.php
+++ b/src/Checkout/Components/StripeOnsitePayment.php
@@ -19,8 +19,8 @@ use SilverStripe\Omnipay\GatewayInfo;
 use SilverStripe\Omnipay\Model\Payment;
 use SilverStripe\Omnipay\Service\PurchaseService;
 use SilverStripe\ORM\FieldType\DBField;
-use SilverStripe\ORM\ValidationException;
-use SilverStripe\ORM\ValidationResult;
+use SilverStripe\Core\Validation\ValidationException;
+use SilverStripe\Core\Validation\ValidationResult;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
 use SilverStripe\View\Requirements;
@@ -143,7 +143,7 @@ class StripeOnsitePayment extends OnsitePayment
         return $fields;
     }
 
-    protected function hasExistingCards(Member $member = null): bool
+    protected function hasExistingCards(?Member $member = null): bool
     {
         if (!$this->isPaymentIntent) {
             return false;

--- a/src/Extensions/MemberExtension.php
+++ b/src/Extensions/MemberExtension.php
@@ -4,9 +4,9 @@ namespace Innoweb\SilvershopStripe\Extensions;
 
 use Innoweb\SilvershopStripe\Model\CreditCard;
 use SilverStripe\Forms\FieldList;
-use SilverStripe\ORM\DataExtension;
+use SilverStripe\Core\Extension;
 
-class MemberExtension extends DataExtension
+class MemberExtension extends Extension
 {
     private static array $db = [
         'StripeCustomerReference' => 'Varchar',

--- a/src/Extensions/PaymentExtension.php
+++ b/src/Extensions/PaymentExtension.php
@@ -3,9 +3,9 @@
 namespace Innoweb\SilvershopStripe\Extensions;
 
 use Innoweb\SilvershopStripe\Model\CreditCard;
-use SilverStripe\ORM\DataExtension;
+use SilverStripe\Core\Extension;
 
-class PaymentExtension extends DataExtension
+class PaymentExtension extends Extension
 {
     private static array $db = [
         'StripePaymentIntentReference' => 'Varchar(255)'


### PR DESCRIPTION
- DataExtension → Extension
- ORM\ValidationException → Core\Validation\ValidationException  
- ORM\ValidationResult → Core\Validation\ValidationResult
- Fix implicit nullable parameter deprecation (PHP 8.4)
- Update composer constraints to allow silverstripe/cms ^6, silverstripe/vendor-plugin ^3, and silvershop/core dev-main